### PR TITLE
docs: update v4/simuler-alderspensjon API documentation

### DIFF
--- a/docs/api/alderspensjon/simulering2025/apidocSimulering2025.yaml
+++ b/docs/api/alderspensjon/simulering2025/apidocSimulering2025.yaml
@@ -39,30 +39,129 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/AlderspensjonSpecV4'
+            example:
+              personId: "02016512345"
+              gradertUttak:
+                fraOgMedDato: "2027-03-01"
+                uttaksgrad: 50
+              heltUttakFraOgMedDato: "2032-03-01"
+              aarIUtlandetEtter16: 0
+              epsPensjon: false
+              eps2G: false
+              fremtidigInntektListe:
+                - aarligInntekt: 600000
+                  fraOgMedDato: "2025-01-01"
+                - aarligInntekt: 0
+                  fraOgMedDato: "2032-03-01"
         required: true
       responses:
         '200':
-          description: Simulering av alderspensjon utført.
+          description: >-
+            Simulering av alderspensjon utført. `simuleringSuksess` er `true`
+            dersom simuleringen var vellykket, og `false` dersom personen ikke
+            hadde tilstrekkelig opptjening eller trygdetid, eller det oppstod
+            en annen kjent feil i simuleringen – se `aarsakListeIkkeSuksess`
+            for detaljer.
           content:
             '*/*':
               schema:
                 $ref: '#/components/schemas/AlderspensjonResultV4'
+              examples:
+                gradertOgHeltUttak:
+                  summary: Vellykket simulering med gradert uttak fra 2027 og helt uttak fra 2032
+                  value:
+                    simuleringSuksess: true
+                    aarsakListeIkkeSuksess: []
+                    harUttak: false
+                    alderspensjon:
+                      - fraOgMedDato: "2027-03-01"
+                        uttaksgrad: 50
+                        delytelseListe:
+                          - pensjonsType: "inntektsPensjon"
+                            belop: 145000
+                          - pensjonsType: "garantiPensjon"
+                            belop: 23000
+                      - fraOgMedDato: "2032-03-01"
+                        uttaksgrad: 100
+                        delytelseListe:
+                          - pensjonsType: "inntektsPensjon"
+                            belop: 290000
+                    forslagVedForLavOpptjening: null
+                forLavOpptjening:
+                  summary: Simulering avslått pga. for lav opptjening, med forslag til alternativt uttakstidspunkt
+                  value:
+                    simuleringSuksess: false
+                    aarsakListeIkkeSuksess:
+                      - statusKode: "AVSLAG_FOR_LAV_OPPTJENING"
+                        statusBeskrivelse: "UtilstrekkeligOpptjeningException"
+                    harUttak: false
+                    alderspensjon: []
+                    forslagVedForLavOpptjening:
+                      gradertUttak:
+                        fraOgMedDato: "2028-03-01"
+                        uttaksgrad: 50
+                      heltUttakFraOgMedDato: "2032-03-01"
         '400':
           description: >-
-            Simulering kunne ikke utføres pga. uakseptable inndata. Det kan
-            være:\
+            Forespørselen mangler obligatoriske felt (f.eks. `personId` eller
+            `heltUttakFraOgMedDato`), eller inneholder et ugyldig datoformat
+            (forventet format: YYYY-MM-DD). `statusKode` i responsen vil
+            være `ANNET` for denne feilsituasjonen.\
 
-            (1) helt uttak ikke etter gradert uttak,\
+            \
 
-            (2) inntekt ikke 1. i måneden,\
+            Merk: De fleste simuleringsfeil returneres som HTTP 200 med
+            `simuleringSuksess: false`. Mulige `statusKode`-verdier på tvers
+            av alle responser:\
 
-            (3) inntekter har lik startdato, \
+            – `AVSLAG_FOR_LAV_OPPTJENING`: Utilstrekkelig pensjonsopptjening
+            for valgt uttakstidspunkt.\
 
-            (4) negativ inntekt.
+            – `AVSLAG_FOR_KORT_TRYGDETID`: Utilstrekkelig trygdetid for valgt
+            uttakstidspunkt.\
+
+            – `BRUKER_FODT_FOR_1943`: Personen er født før 1943 og støttes
+            ikke.\
+
+            – `BRUKER_HAR_IKKE_LOPENDE_ALDERSPENSJON`: Endring av løpende
+            uttak ble forsøkt, men personen har ikke løpende alderspensjon.\
+
+            – `BRUKER_HAR_LOPENDE_ALDERSPPENSJON_PAA_GAMMELT_REGELVERK`:
+            Personen har alderspensjon på gammelt regelverk (pre-2011).\
+
+            – `UGYLDIG_ENDRING_AV_UTTAKSGRAD`: Ugyldig endring av uttaksgrad
+            for person med løpende alderspensjon.\
+
+            – `ANNET`: Annen uklassifisert feil, inkludert manglende
+            obligatoriske felt og ugyldig datoformat.
           content:
             '*/*':
               schema:
                 $ref: '#/components/schemas/AlderspensjonResultV4'
+              example:
+                simuleringSuksess: false
+                aarsakListeIkkeSuksess:
+                  - statusKode: "ANNET"
+                    statusBeskrivelse: "BadRequestException"
+                harUttak: false
+                alderspensjon: []
+                forslagVedForLavOpptjening: null
+        '500':
+          description: >-
+            Intern serverfeil. Simuleringen kunne ikke gjennomføres pga.
+            en uventet feil.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/AlderspensjonResultV4'
+              example:
+                simuleringSuksess: false
+                aarsakListeIkkeSuksess:
+                  - statusKode: "ANNET"
+                    statusBeskrivelse: "RuntimeException"
+                harUttak: false
+                alderspensjon: []
+                forslagVedForLavOpptjening: null
       security:
         - BearerAuthentication: []
   /simuler/alderspensjon/v3:
@@ -438,19 +537,47 @@ components:
       type: object
       properties:
         personId:
+          description: >-
+            Fødselsnummer (11 siffer) eller D-nummer for personen som skal
+            simuleres.
           type: string
         gradertUttak:
+          description: >-
+            Spesifikasjon for gradert (delvis) uttak av alderspensjon. Utelates
+            dersom det kun simuleres helt uttak. Uttaksgraden påvirker størrelsen
+            på pensjonsutbetalingen frem til helt uttak.
           $ref: '#/components/schemas/GradertUttakSpecV4'
         heltUttakFraOgMedDato:
+          description: >-
+            Dato for oppstart av helt (100 %) uttak av alderspensjon, i formatet
+            "YYYY-MM-DD". Må være første dag i en måned. Dersom gradert uttak
+            er oppgitt, må denne datoen være etter datoen for gradert uttak.
           type: string
         aarIUtlandetEtter16:
+          description: >-
+            Antall år personen har bodd utenfor Norge etter fylte 16 år. Brukes
+            til beregning av trygdetid, som påvirker størrelsen på
+            garantipensjonen. Standardverdi er 0.
           type: integer
           format: int32
         epsPensjon:
+          description: >-
+            Angir om ektefelle, partner eller samboer (EPS) har pensjon.
+            Påvirker størrelsen på garantipensjonen – satsen reduseres dersom
+            EPS har pensjon.
           type: boolean
         eps2G:
+          description: >-
+            Angir om ektefelle, partner eller samboer (EPS) har inntekt over
+            2 ganger grunnbeløpet (2G). Påvirker størrelsen på
+            garantipensjonen – satsen reduseres dersom EPS har inntekt over 2G.
           type: boolean
         fremtidigInntektListe:
+          description: >-
+            Liste over fremtidige inntekter for personen. Inntektene påvirker
+            pensjonsopptjeningen frem til uttaksdato og dermed størrelsen på
+            alderspensjonen. Alle datoer må være den 1. i måneden, og det kan
+            ikke være duplikate startdatoer eller negative beløp.
           type: array
           items:
             $ref: '#/components/schemas/PensjonInntektSpecV4'
@@ -462,29 +589,48 @@ components:
       type: object
       properties:
         fraOgMedDato:
+          description: >-
+            Dato for oppstart av gradert uttak, i formatet "YYYY-MM-DD".
+            Må være første dag i en måned.
           type: string
         uttaksgrad:
+          description: >-
+            Uttaksgrad i prosent for gradert uttak.
+            Gyldige verdier: 20, 40, 50, 60, 80.
           type: integer
           format: int32
+          enum: [20, 40, 50, 60, 80]
     PensjonInntektSpecV4:
       type: object
       properties:
         aarligInntekt:
+          description: >-
+            Årlig pensjonsgivende inntekt i kroner. Ikke-negativ verdi.
+            Sett til 0 fra uttaksdato for å angi ingen inntekt etter uttak.
           type: integer
           format: int32
         fraOgMedDato:
+          description: >-
+            Dato inntekten gjelder fra og med, i formatet "YYYY-MM-DD".
+            Må være første dag i en måned.
           type: string
     AlderspensjonFraFolketrygdenV4:
       type: object
       properties:
         fraOgMedDato:
+          description: >-
+            Første dato for perioden med alderspensjon, i formatet "YYYY-MM-DD".
           type: string
           format: date
         delytelseListe:
+          description: >-
+            Liste over delytelser (pensjonskomponenter) som inngår i perioden.
           type: array
           items:
             $ref: '#/components/schemas/PensjonDelytelseV4'
         uttaksgrad:
+          description: >-
+            Uttaksgrad i prosent for perioden.
           type: integer
           format: int32
       required:
@@ -495,18 +641,35 @@ components:
       type: object
       properties:
         simuleringSuksess:
+          description: >-
+            Angir om simuleringen var vellykket. `false` dersom personen ikke
+            hadde tilstrekkelig opptjening eller trygdetid, eller det oppstod
+            en kjent feil i simuleringen.
           type: boolean
         aarsakListeIkkeSuksess:
+          description: >-
+            Liste over årsaker til at simuleringen ikke var vellykket.
+            Tom liste dersom `simuleringSuksess` er `true`.
           type: array
           items:
             $ref: '#/components/schemas/PensjonSimuleringStatusV4'
         alderspensjon:
+          description: >-
+            Liste over simulerte alderspensjonsperioder fra folketrygden.
+            Tom liste dersom `simuleringSuksess` er `false`.
           type: array
           items:
             $ref: '#/components/schemas/AlderspensjonFraFolketrygdenV4'
         forslagVedForLavOpptjening:
+          description: >-
+            Forslag til tidligste mulige uttaksdato dersom personen ikke har
+            tilstrekkelig opptjening for det oppgitte uttakstidspunktet.
+            Kun satt dersom `statusKode` er `AVSLAG_FOR_LAV_OPPTJENING`.
           $ref: '#/components/schemas/ForslagVedForLavOpptjeningV4'
         harUttak:
+          description: >-
+            Angir om personen allerede har løpende alderspensjon fra Nav
+            på simuleringstidspunktet.
           type: boolean
       required:
         - aarsakListeIkkeSuksess
@@ -517,8 +680,12 @@ components:
       type: object
       properties:
         gradertUttak:
+          description: >-
+            Forslag til gradert uttak. `null` dersom kun helt uttak foreslås.
           $ref: '#/components/schemas/GradertUttakV4'
         heltUttakFraOgMedDato:
+          description: >-
+            Forslag til tidligste dato for helt uttak, i formatet "YYYY-MM-DD".
           type: string
           format: date
       required:
@@ -527,9 +694,13 @@ components:
       type: object
       properties:
         fraOgMedDato:
+          description: >-
+            Forslag til dato for gradert uttak, i formatet "YYYY-MM-DD".
           type: string
           format: date
         uttaksgrad:
+          description: >-
+            Forslag til uttaksgrad i prosent.
           type: integer
           format: int32
       required:
@@ -539,8 +710,18 @@ components:
       type: object
       properties:
         pensjonsType:
+          description: >-
+            Type pensjonskomponent. `inntektsPensjon` er inntektsbasert pensjon
+            basert på pensjonsopptjening. `garantiPensjon` er garantipensjon
+            som sikrer et minstenivå for alderspensjonen uavhengig av
+            opptjening.
           type: string
+          enum:
+            - inntektsPensjon
+            - garantiPensjon
         belop:
+          description: >-
+            Årlig beløp for delytelsen i kroner.
           type: integer
           format: int32
       required:
@@ -550,8 +731,43 @@ components:
       type: object
       properties:
         statusKode:
+          description: >-
+            Statuskode som angir årsak til at simuleringen ikke var vellykket.
+
+            - `AVSLAG_FOR_LAV_OPPTJENING`: Utilstrekkelig pensjonsopptjening
+              for valgt uttakstidspunkt. Se `forslagVedForLavOpptjening` for
+              tidligste mulige alternativ.
+
+            - `AVSLAG_FOR_KORT_TRYGDETID`: Utilstrekkelig trygdetid for valgt
+              uttakstidspunkt.
+
+            - `BRUKER_FODT_FOR_1943`: Personen er født før 1943 og støttes
+              ikke av dette API-et.
+
+            - `BRUKER_HAR_IKKE_LOPENDE_ALDERSPENSJON`: Endring av løpende
+              uttak ble forsøkt, men personen har ikke løpende alderspensjon.
+
+            - `BRUKER_HAR_LOPENDE_ALDERSPPENSJON_PAA_GAMMELT_REGELVERK`:
+              Personen har alderspensjon på gammelt regelverk (pre-2011)
+              som ikke støttes av dette API-et.
+
+            - `UGYLDIG_ENDRING_AV_UTTAKSGRAD`: Ugyldig endring av uttaksgrad
+              for person med løpende alderspensjon.
+
+            - `ANNET`: Annen uklassifisert feil.
           type: string
+          enum:
+            - AVSLAG_FOR_LAV_OPPTJENING
+            - AVSLAG_FOR_KORT_TRYGDETID
+            - BRUKER_FODT_FOR_1943
+            - BRUKER_HAR_IKKE_LOPENDE_ALDERSPENSJON
+            - BRUKER_HAR_LOPENDE_ALDERSPPENSJON_PAA_GAMMELT_REGELVERK
+            - UGYLDIG_ENDRING_AV_UTTAKSGRAD
+            - ANNET
         statusBeskrivelse:
+          description: >-
+            Tekstlig beskrivelse av status, typisk navn på Java-unntaket som
+            utløste feilen.
           type: string
       required:
         - statusBeskrivelse

--- a/docs/api/alderspensjon/simulering2025/apidocSimulering2025.yaml
+++ b/docs/api/alderspensjon/simulering2025/apidocSimulering2025.yaml
@@ -665,7 +665,9 @@ components:
             Forslag til tidligste mulige uttaksdato dersom personen ikke har
             tilstrekkelig opptjening for det oppgitte uttakstidspunktet.
             Kun satt dersom `statusKode` er `AVSLAG_FOR_LAV_OPPTJENING`.
-          $ref: '#/components/schemas/ForslagVedForLavOpptjeningV4'
+          anyOf:
+            - $ref: '#/components/schemas/ForslagVedForLavOpptjeningV4'
+            - type: 'null'
         harUttak:
           description: >-
             Angir om personen allerede har løpende alderspensjon fra Nav

--- a/docs/api/alderspensjon/simulering2025/apidocSimulering2025.yaml
+++ b/docs/api/alderspensjon/simulering2025/apidocSimulering2025.yaml
@@ -684,7 +684,9 @@ components:
         gradertUttak:
           description: >-
             Forslag til gradert uttak. `null` dersom kun helt uttak foreslås.
-          $ref: '#/components/schemas/GradertUttakV4'
+          anyOf:
+            - $ref: '#/components/schemas/GradertUttakV4'
+            - type: 'null'
         heltUttakFraOgMedDato:
           description: >-
             Forslag til tidligste dato for helt uttak, i formatet "YYYY-MM-DD".


### PR DESCRIPTION
Oppdaterer OpenAPI-dokumentasjon for v4/simuler-alderspensjon.

Request: beskrivelser pa alle felt, enum for uttaksgrad (20/40/50/60/80), realistisk eksempel.

Response: beskrivelser pa alle felt, enum for pensjonsType og alle 7 statusKode-verdier.

HTTP-statuskoder: 200 med to eksempler (suksess + AVSLAG_FOR_LAV_OPPTJENING), 400 med alle statusKode-verdier listet, 500 lagt til.